### PR TITLE
Add reagents section to production plan

### DIFF
--- a/src/app/core/model/conf/configuration-data.ts
+++ b/src/app/core/model/conf/configuration-data.ts
@@ -34,4 +34,5 @@ export class ConfigurationData {
     consortiaToConstructSymbols: string[];
     qcTypes: string[];
     qcStatuses: string[];
+    reagents: string[];
 }

--- a/src/app/feature-modules/attempts/attempts.module.ts
+++ b/src/app/feature-modules/attempts/attempts.module.ts
@@ -12,6 +12,7 @@ import { PhenotypingAttemptComponent } from './components/phenotyping/phenotypin
 // tslint:disable-next-line:max-line-length
 import { TissueDistributionCentreComponent } from './components/phenotyping/tissue-distribution-centre/tissue-distribution-centre.component';
 import { NucleaseComponent } from './components/production/crispr/nuclease/nuclease.component';
+import { ReagentsComponent } from './components/production/crispr/reagents/reagents.component';
 
 @NgModule({
   declarations: [
@@ -23,7 +24,8 @@ import { NucleaseComponent } from './components/production/crispr/nuclease/nucle
     GuidesComponent,
     PhenotypingAttemptComponent,
     TissueDistributionCentreComponent,
-    NucleaseComponent
+    NucleaseComponent,
+    ReagentsComponent
   ],
   imports: [
     SharedModule,

--- a/src/app/feature-modules/attempts/components/production/crispr/crispr-attempt/crispr-attempt.component.html
+++ b/src/app/feature-modules/attempts/components/production/crispr/crispr-attempt/crispr-attempt.component.html
@@ -15,4 +15,6 @@
 
   <app-nuclease [crisprAttempt]="crisprAttempt" [canUpdatePlan]="canUpdatePlan"></app-nuclease>
 
+  <app-reagents [crisprAttempt]="crisprAttempt" [canUpdatePlan]="canUpdatePlan"></app-reagents>
+
 </form>

--- a/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.css
+++ b/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.css
@@ -1,0 +1,15 @@
+table,
+th,
+tr,
+td {
+  padding: 10px;
+  text-align: left;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: rgba(0, 0, 0, 0.12);
+  font-size: 14px;
+}
+
+td {
+    min-width: 150px;
+}

--- a/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.html
+++ b/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.html
@@ -1,0 +1,61 @@
+<mat-card>
+    <mat-card-subtitle>Reagents</mat-card-subtitle>
+    <mat-card-content>
+        <table class="mat-elevation-z8">
+            <tr>
+                <th>Name</th>
+                <th>Concentration (ng/uL)</th>
+                <th></th>
+            </tr>
+            <ng-template ngFor let-reagent [ngForOf]="crisprAttempt.reagents">
+                <div *ngIf="canUpdatePlan; then editableRow else readOnlyRow">
+                </div>
+                <ng-template #editableRow>
+                    <tr>
+                        <td>
+
+                            <mat-select [(ngModel)]="reagent.reagentName">
+                                <mat-option *ngFor="let reagentName of reagentNames" [value]="reagentName.name">
+                                    {{reagentName.name}}
+                                </mat-option>
+                            </mat-select>
+                        </td>
+                        <td>
+                            <input appDigitOnly decimal="true" [ngClass]="{'required': concentration.invalid}"
+                                name="concentration" #concentration="ngModel" [(ngModel)]="reagent.concentration"
+                                (keyup)="onReagentChanged(reagent)" [ngModelOptions]="{standalone: true}">
+                        </td>
+                        <td>
+                            <button (click)="onClickToDeleteReagent(reagent)">
+                                <mat-icon aria-hidden="false" aria-label="icon">delete</mat-icon>
+                            </button>
+                        </td>
+
+                    </tr>
+
+                </ng-template>
+                <ng-template #readOnlyRow>
+                    <tr>
+                        <td>
+                            {{ reagent.reagentName || "Not defined" }}
+                        </td>
+                        <td>
+                            {{ reagent.concentration || "Not defined" }}
+                        </td>
+
+
+                    </tr>
+                </ng-template>
+            </ng-template>
+
+            <tr *ngIf="canUpdatePlan">
+                <td class="no_border"><button (click)="addRow()" [disabled]="false">
+                        <mat-icon aria-hidden="false" aria-label="add icon">add</mat-icon>
+                    </button>
+                </td>
+            </tr>
+
+        </table>
+
+    </mat-card-content>
+</mat-card>

--- a/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.spec.ts
+++ b/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ReagentsComponent } from './reagents.component';
+
+describe('ReagentsComponent', () => {
+  let component: ReagentsComponent;
+  let fixture: ComponentFixture<ReagentsComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ReagentsComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ReagentsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.ts
+++ b/src/app/feature-modules/attempts/components/production/crispr/reagents/reagents.component.ts
@@ -1,0 +1,87 @@
+import { Component, OnInit, Input } from '@angular/core';
+import { CrisprAttempt } from 'src/app/feature-modules/attempts';
+import { ConfigurationData, ConfigurationDataService } from 'src/app/core';
+import { NamedValue } from 'src/app/core/model/common/named-value';
+import { MatDialog } from '@angular/material/dialog';
+import { Reagent } from 'src/app/feature-modules/attempts/model/production/crispr/reagent';
+import { DeleteConfirmationComponent } from 'src/app/shared/components/delete-confirmation/delete-confirmation.component';
+import { DistributionProduct } from 'src/app/feature-modules/plans/model/outcomes/distribution-product';
+import { InputHandlerService } from 'src/app/core/services/input-handler.service';
+
+@Component({
+  selector: 'app-reagents',
+  templateUrl: './reagents.component.html',
+  styleUrls: ['./reagents.component.css']
+})
+export class ReagentsComponent implements OnInit {
+  @Input() crisprAttempt: CrisprAttempt;
+  @Input() canUpdatePlan: boolean;
+
+  configurationData: ConfigurationData;
+  reagentNames: NamedValue[] = [];
+
+  tmpIndexRowName = 'tmp_id';
+  nextNewId = -1;
+
+  constructor(
+    private configurationDataService: ConfigurationDataService,
+    private inputHandlerService: InputHandlerService,
+    public dialog: MatDialog) { }
+
+  ngOnInit(): void {
+    this.loadConfigurationData();
+  }
+
+  loadConfigurationData() {
+    this.configurationDataService.getConfigurationData().subscribe(data => {
+      this.configurationData = data;
+      this.reagentNames = this.configurationData.reagents.map(x => ({ name: x }));
+    });
+  }
+
+  onReagentChanged(reagent: Reagent) {
+    reagent.concentration = this.inputHandlerService.getNumericValueOrNull(reagent.concentration);
+  }
+
+  addRow() {
+    const reagent: Reagent = new Reagent();
+    reagent[this.tmpIndexRowName] = this.nextNewId--;
+    this.crisprAttempt.reagents.push(reagent);
+  }
+
+  onClickToDeleteReagent(reagent: Reagent) {
+    if (this.isNewRecord(reagent)) {
+      this.deleteReagent(reagent);
+    } else {
+      this.showDeleteMutationConfirmationDialog(reagent);
+    }
+  }
+
+  showDeleteMutationConfirmationDialog(reagent: Reagent) {
+    const dialogRef = this.dialog.open(DeleteConfirmationComponent, {
+      width: '250px',
+      data: { confirmed: false }
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.deleteReagent(reagent);
+      }
+    });
+  }
+
+  deleteReagent(reagent: Reagent) {
+    if (this.isNewRecord(reagent)) {
+      this.crisprAttempt.reagents = this.crisprAttempt.reagents
+        .filter(x => x[this.tmpIndexRowName] !== reagent[this.tmpIndexRowName]);
+    } else {
+      this.crisprAttempt.reagents = this.crisprAttempt.reagents
+        .filter(x => x.id !== reagent.id);
+    }
+
+  }
+
+  private isNewRecord(reagent: Reagent) {
+    return reagent.id == null;
+  }
+
+}

--- a/src/app/feature-modules/plans/components/production-plan/production-plan.component.ts
+++ b/src/app/feature-modules/plans/components/production-plan/production-plan.component.ts
@@ -24,7 +24,6 @@ export class ProductionPlanComponent implements OnInit {
 
   // Content previous modifications so we can tell when something has changed
   originalPlanAsString: string;
-  originalOutcomesAsString: string;
 
   canUpdatePlan: boolean;
   loading = false;
@@ -82,7 +81,6 @@ export class ProductionPlanComponent implements OnInit {
           x.tpn = this.plan.tpn;
           this.loadMutationsByOutcomes(x);
         });
-        this.originalOutcomesAsString = JSON.stringify(this.outcomes);
       }
       /* tslint:enable:no-string-literal */
     }, error => {
@@ -120,14 +118,11 @@ export class ProductionPlanComponent implements OnInit {
   }
 
   /**
-   * Updates the information of the plan and/or its outcomes.
+   * Updates the information of the plan.
    */
   update() {
     if (this.planHasChanged()) {
       this.updatePlan();
-    }
-    if (this.outcomesChanged()) {
-      this.updateOutcomes();
     }
   }
 
@@ -157,38 +152,12 @@ export class ProductionPlanComponent implements OnInit {
       );
   }
 
-  private updateOutcomes() {
-    this.outcomes.forEach(x => {
-      this.outcomeService.updateOutcome(this.plan.pin, x).subscribe((changeResponse: ChangeResponse) => {
-        this.loading = false;
-        // this.originalPlanAsString = JSON.stringify(this.plan);
-        if (changeResponse && changeResponse.history.length > 0) {
-          this.changeDetails = changeResponse.history[0];
-          this.snackBar.openFromComponent(UpdateNotificationComponent, {
-            duration: 3000,
-            data: this.changeDetails
-          });
-        }
-        this.error = null;
-        this.reloadForPin(this.plan.pin);
-      },
-        error => {
-          console.error('Error while updating plan outcome', error);
-          this.error = error;
-        }
-      );
-    });
-  }
-
   enableUpdateButton() {
-    return this.planHasChanged() || this.outcomesChanged();
+    return this.planHasChanged();
   }
 
   planHasChanged() {
     return this.originalPlanAsString !== JSON.stringify(this.plan);
   }
 
-  outcomesChanged() {
-    return this.originalOutcomesAsString !== JSON.stringify(this.outcomes);
-  }
 }


### PR DESCRIPTION
- Add logic to edit, delete and add reagents
- Remove update outcomes logic in the production plan page as that should be managed in the outcome detail page