### PR TITLE
Added unsafe-inline to the CSP script-src definition and removed unsa…

### DIFF
--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -32,7 +32,7 @@ server {
       add_header  Content-Type    text/css;
   }
 
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' https://fonts.googleapis.com/ 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com/ data:; frame-ancestors 'none'; connect-src http://www.gentar.org http://www.gentar.org:443 https://www.gentar.org 'self'";
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' https://fonts.googleapis.com/ 'unsafe-inline'; img-src 'self' data:; font-src 'self' https://fonts.gstatic.com/ data:; frame-ancestors 'none'; connect-src http://www.gentar.org http://www.gentar.org:443 https://www.gentar.org 'self'";
   add_header Referrer-Policy "no-referrer, strict-origin-when-cross-origin";
   add_header Strict-Transport-Security "max-age=63072000; includeSubDomains";
   add_header X-Content-Type-Options nosniff;


### PR DESCRIPTION
…fe-eval. unsafe-inline is required for styles, but unsafe-eval is no longer required if using a production build (with the reflect polyfills removed as they are only needed for JIT)